### PR TITLE
Delete empty translations

### DIFF
--- a/src/Concerns/Translatable.php
+++ b/src/Concerns/Translatable.php
@@ -295,12 +295,22 @@ trait Translatable
      * @param  mixed $value
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function translateAttribute(string $langCode, string $attribute, $value): Model
+    public function translateAttribute(string $langCode, string $attribute, $value): ?Model
     {
-        return $this->translations()->updateOrCreate([
+        $translation = $this->translations()->firstOrNew([
             'language_code' => $langCode,
             'key' => $attribute,
         ], compact('value'));
+
+        if (is_string($value) && $value === '' || $value === null) {
+            $translation->delete();
+
+            return null;
+        }
+
+        $translation->save();
+
+        return $translation;
     }
 
     /**

--- a/src/Http/Middleware/AutoTranslate.php
+++ b/src/Http/Middleware/AutoTranslate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Signifly\Translator\Http\Middleware;
+
+use Closure;
+use Signifly\Translator\Facades\Translator;
+
+class AutoTranslate
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        Translator::enableAutoTranslation();
+
+        return $next($request);
+    }
+}

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -192,4 +192,42 @@ class TranslatableTest extends TestCase
         $this->assertTrue($columns->contains('created_at'));
         $this->assertTrue($columns->contains('updated_at'));
     }
+
+    /** @test */
+    public function it_deletes_the_translation_if_an_empty_value_is_provided()
+    {
+        // Given a product with translations
+        $this->product->updateAndTranslate('da', [
+            'name' => 'new name',
+            'description' => 'new description',
+        ]);
+
+        tap($this->product->fresh(), function ($product) {
+            $this->assertEquals('name 1', $product->name);
+            $this->assertEquals('description 1', $product->description);
+            $this->assertTrue($product->hasTranslation('da', 'name'));
+            $this->assertTrue($product->hasTranslation('da', 'description'));
+            $this->assertEquals(
+                'new name',
+                $product->getTranslationValue('da', 'name')
+            );
+            $this->assertEquals(
+                'new description',
+                $product->getTranslationValue('da', 'description')
+            );
+        });
+
+        // Then set the description to an empty value
+        $this->product->updateAndTranslate('da', [
+            'description' => '',
+        ]);
+
+        // Assert that the attribute is empty and
+        // the translation has been deleted
+        tap($this->product->fresh(), function ($product) {
+            $this->assertEquals('description 1', $product->description);
+            $this->assertFalse($product->hasTranslation('da', 'description'));
+            $this->assertNull($product->getTranslationValue('da', 'description'));
+        });
+    }
 }


### PR DESCRIPTION
## Added
- A middleware that enables auto translation

## Changed
- When an empty translation value is provided, the associated translation is deleted